### PR TITLE
Update schema args as objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -49,13 +49,13 @@
       "items": {
         "oneOf": [
           {
-            "type": "string"
+            "$ref": "#/$defs/string_argument"
           },
           {
-            "type": "number"
+            "$ref": "#/$defs/number_argument"
           },
           {
-            "type": "boolean"
+            "$ref": "#/$defs/boolean_argument"
           },
           {
             "$ref": "#/$defs/symbol_argument"
@@ -396,6 +396,42 @@
         }
       },
       "required": ["symbol"],
+      "type": "object"
+    },
+    "string_argument": {
+      "additionalProperties": false,
+      "description": "A step argument containing a string.",
+      "properties": {
+        "string": {
+          "description": "The value. The string must be valid.",
+          "type": "string"
+        }
+      },
+      "required": ["string"],
+      "type": "object"
+    },
+    "number_argument": {
+      "additionalProperties": false,
+      "description": "A step argument containing a number.",
+      "properties": {
+        "number": {
+          "description": "The value. The number must be valid.",
+          "type": "number"
+        }
+      },
+      "required": ["number"],
+      "type": "object"
+    },
+    "boolean_argument": {
+      "additionalProperties": false,
+      "description": "A step argument containing a boolean.",
+      "properties": {
+        "boolean": {
+          "description": "The boolean value. The value must be all lowercase.",
+          "type": "boolean"
+        }
+      },
+      "required": ["boolean"],
       "type": "object"
     },
     "hex_argument": {

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
   name='seq-json-schema',
   packages=['seq-json-schema'],
   url='https://github.com/NASA-AMMOS/seq-json-schema',
-  version='1.0.10'
+  version='1.0.11'
 )

--- a/test/invalid-seq-json/activate-extra-property.seq.json
+++ b/test/invalid-seq-json/activate-extra-property.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with extra property.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/activate-missing-sequence.seq.json
+++ b/test/invalid-seq-json/activate-missing-sequence.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2, missing sequence tag.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/activate-missing-time.seq.json
+++ b/test/invalid-seq-json/activate-missing-time.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2, missing time tag.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/activate-missing-type.seq.json
+++ b/test/invalid-seq-json/activate-missing-type.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2, missing type tag.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/activate-noninteger-engine.seq.json
+++ b/test/invalid-seq-json/activate-noninteger-engine.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into noninteger engine.",
       "engine": 2.5,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/activate-nonstring-epoch.seq.json
+++ b/test/invalid-seq-json/activate-nonstring-epoch.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with nonstring epoch.",
       "engine": 2,
       "epoch": 7,

--- a/test/invalid-seq-json/activate-nonstring-sequence.seq.json
+++ b/test/invalid-seq-json/activate-nonstring-sequence.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with nonstring sequence.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/args-invalid-type.seq.json
+++ b/test/invalid-seq-json/args-invalid-type.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": 7,
+      "args": { "number": 7 },
       "description": "Epoch-relative activate step for test.mod into engine 2 with invalid arg type.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/command-extra-property.seq.json
+++ b/test/invalid-seq-json/command-extra-property.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with extra property.",
       "models": [
         {

--- a/test/invalid-seq-json/command-missing-stem.seq.json
+++ b/test/invalid-seq-json/command-missing-stem.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with missing stem.",
       "models": [
         {

--- a/test/invalid-seq-json/command-missing-time.seq.json
+++ b/test/invalid-seq-json/command-missing-time.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with missing time.",
       "models": [
         {

--- a/test/invalid-seq-json/command-missing-type.seq.json
+++ b/test/invalid-seq-json/command-missing-type.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with missing type.",
       "models": [
         {

--- a/test/invalid-seq-json/command-nonarray-models.seq.json
+++ b/test/invalid-seq-json/command-nonarray-models.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with nonarray models.",
       "models": 7,
       "stem": "FAKE_COMMAND1",

--- a/test/invalid-seq-json/command-nonstring-stem.seq.json
+++ b/test/invalid-seq-json/command-nonstring-stem.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with nonstring stem.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-block-extra-property.seq.json
+++ b/test/invalid-seq-json/ground-block-extra-property.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step with extra property.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-block-missing-name.seq.json
+++ b/test/invalid-seq-json/ground-block-missing-name.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step missing name.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-block-missing-time.seq.json
+++ b/test/invalid-seq-json/ground-block-missing-time.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        "SEQSTR",
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step missing time.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-block-missing-type.seq.json
+++ b/test/invalid-seq-json/ground-block-missing-type.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step missing type.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-block-nonarray-models.seq.json
+++ b/test/invalid-seq-json/ground-block-nonarray-models.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step with nonarray models field.",
       "models": 7,
       "name": "SEQTRAN_directive",

--- a/test/invalid-seq-json/ground-block-nonstring-name.seq.json
+++ b/test/invalid-seq-json/ground-block-nonstring-name.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step with nonstring name.",
       "models": [
         {

--- a/test/invalid-seq-json/ground-event-extra-property.seq.json
+++ b/test/invalid-seq-json/ground-event-extra-property.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with extra property.",
       "models": [

--- a/test/invalid-seq-json/ground-event-missing-name.seq.json
+++ b/test/invalid-seq-json/ground-event-missing-name.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with missing name.",
       "models": [

--- a/test/invalid-seq-json/ground-event-missing-time.seq.json
+++ b/test/invalid-seq-json/ground-event-missing-time.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with missing time.",
       "models": [

--- a/test/invalid-seq-json/ground-event-missing-type.seq.json
+++ b/test/invalid-seq-json/ground-event-missing-type.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with missing type.",
       "models": [

--- a/test/invalid-seq-json/ground-event-nonarray-models.seq.json
+++ b/test/invalid-seq-json/ground-event-nonarray-models.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with nonarray models.",
       "models": 7,

--- a/test/invalid-seq-json/ground-event-nonstring-name.seq.json
+++ b/test/invalid-seq-json/ground-event-nonstring-name.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with nonstring name.",
       "models": [

--- a/test/invalid-seq-json/nonstring-description.seq.json
+++ b/test/invalid-seq-json/nonstring-description.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": 7,
       "models": [
         {

--- a/test/invalid-seq-json/time-extra-property.seq.json
+++ b/test/invalid-seq-json/time-extra-property.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/time-missing-type.seq.json
+++ b/test/invalid-seq-json/time-missing-type.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/time-nonenum-type.seq.json
+++ b/test/invalid-seq-json/time-nonenum-type.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/invalid-seq-json/time-nonstring-tag.seq.json
+++ b/test/invalid-seq-json/time-nonstring-tag.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/valid-seq-json/activate.seq.json
+++ b/test/valid-seq-json/activate.seq.json
@@ -9,7 +9,13 @@
   ],
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string", { "symbol": "local_float_1" }],
+      "args": [
+        { "number": 30 },
+        { "number": 4.3 },
+        { "boolean": true },
+        { "string": "test_string" },
+        { "symbol": "local_float_1" }
+      ],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/valid-seq-json/all-possible-fields.seq.json
+++ b/test/valid-seq-json/all-possible-fields.seq.json
@@ -3,7 +3,7 @@
   "metadata": {
     "onboard_path": "/eng",
     "onboard_name": "test.mod",
-    "lgo": false,
+    "lgo": { "boolean": false },
     "other_arbitrary_metadata": "test_metadata"
   },
   "locals": [
@@ -44,7 +44,7 @@
   ],
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",
@@ -75,7 +75,7 @@
       "type": "activate"
     },
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with all possible fields.",
       "models": [
         {
@@ -105,7 +105,15 @@
       "metadata": {}
     },
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step with required fields.",
       "models": [
         {
@@ -136,8 +144,8 @@
     },
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with all possible fields.",
       "models": [

--- a/test/valid-seq-json/command.seq.json
+++ b/test/valid-seq-json/command.seq.json
@@ -10,7 +10,7 @@
   ],
   "steps": [
     {
-      "args": [30, 4.3, false, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": false }, { "string": "test_string" }],
       "description": "Absolute-timed standard command step with all possible fields.",
       "models": [
         {

--- a/test/valid-seq-json/example-seq-ieee.seq.json
+++ b/test/valid-seq-json/example-seq-ieee.seq.json
@@ -14,7 +14,7 @@
       "type": "command",
       "time": { "tag": "2020-173T20:00:00.000", "type": "ABSOLUTE" },
       "stem": "TURN_IMAGER_HEATER_ON",
-      "args": ["SIDE_A"],
+      "args": [{ "string": "SIDE_A" }],
       "description": "Absolute-timed command to turn a heater on, with simulated telemetry change 5 minutes later.",
       "models": [{ "offset": "00:05:00", "variable": "IMAGER_A_WARMED_UP", "value": true }]
     },
@@ -23,14 +23,14 @@
       "time": { "tag": "00:10:00.000", "type": "COMMAND_RELATIVE" },
       "engine": 2,
       "sequence": "/eng/configure_imager.seq",
-      "args": ["MOSAIC", true, 10],
+      "args": [{ "string": "MOSAIC" }, { "boolean": true }, { "number": 10 }],
       "description": "Relative-timed sequence activate"
     },
     {
       "type": "command",
       "time": { "type": "EPOCH_RELATIVE", "tag": "-00:00:15.54" },
       "stem": "TAKE_IMAGE",
-      "args": ["HI_RES"],
+      "args": [{ "string": "HI_RES" }],
       "description": "Epoch-relative timed command, with metadata",
       "metadata": {
         "source": "Expanded from activity TAKE_GANYMEDE_FLYBY_IMAGE_045"
@@ -39,7 +39,7 @@
     {
       "type": "ground_block",
       "name": "process_image_data",
-      "args": ["compression_algorithm", "register"],
+      "args": [{ "string": "compression_algorithm" }, { "string": "register" }],
       "time": { "type": "COMMAND_COMPLETE" },
       "description": "Command-complete timed ground block, using parameter passing from input parameters."
     },
@@ -47,7 +47,10 @@
       "type": "ground_event",
       "time": { "tag": "2020-174T04:40:00.000", "type": "ABSOLUTE" },
       "name": "SIMULATE_FILE_UPLINK",
-      "args": ["/usr/mschaffe/ganymede_flyby_046_images.seq.json", "/eng/ganymede_flyby_046_images.seq"],
+      "args": [
+        { "string": "/usr/mschaffe/ganymede_flyby_046_images.seq.json" },
+        { "string": "/eng/ganymede_flyby_046_images.seq" }
+      ],
       "description": "Ground event step, simulating a file uplink (not a real command)"
     }
   ]

--- a/test/valid-seq-json/ground-block.seq.json
+++ b/test/valid-seq-json/ground-block.seq.json
@@ -3,7 +3,15 @@
   "metadata": {},
   "steps": [
     {
-      "args": ["SEQSTR", "2019-365T00:00:00", "2020-025T00:00:00", "BOTH", "", "", "real_time_cmds"],
+      "args": [
+        { "string": "SEQSTR" },
+        { "string": "2019-365T00:00:00" },
+        { "string": "2020-025T00:00:00" },
+        { "string": "BOTH" },
+        { "string": "" },
+        { "string": "" },
+        { "string": "real_time_cmds" }
+      ],
       "description": "Ground activity step with required fields.",
       "models": [
         {

--- a/test/valid-seq-json/ground-event.seq.json
+++ b/test/valid-seq-json/ground-event.seq.json
@@ -4,8 +4,8 @@
   "steps": [
     {
       "args": [
-        "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf",
-        "d:/tmp/eng_nom_htr_off.mod"
+        { "string": "/domops/data/nsyt/189/seq/satf_sct/nsy.orf.f2_seq_eng_nom_htr_off_mod.r1.satf" },
+        { "string": "d:/tmp/eng_nom_htr_off.mod" }
       ],
       "description": "Ground event step with all possible fields.",
       "models": [

--- a/test/valid-seq-json/load.seq.json
+++ b/test/valid-seq-json/load.seq.json
@@ -3,7 +3,7 @@
   "metadata": {},
   "steps": [
     {
-      "args": [7],
+      "args": [{ "number": 7 }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",

--- a/test/valid-seq-json/metadata.seq.json
+++ b/test/valid-seq-json/metadata.seq.json
@@ -3,7 +3,7 @@
   "metadata": {
     "onboard_path": "/eng",
     "onboard_name": "test.mod",
-    "lgo": false,
+    "lgo": { "boolean": false },
     "other_arbitrary_metadata": "test_metadata"
   }
 }

--- a/test/valid-seq-json/rtc.seq.json
+++ b/test/valid-seq-json/rtc.seq.json
@@ -11,7 +11,7 @@
   "immediate_commands": [
     {
       "stem": "IC",
-      "args": ["1", 2, 3.0],
+      "args": [{ "string": "1" }, { "number": 2 }, { "number": 3.0 }],
       "description": "immediate command",
       "metadata": {}
     },

--- a/test/valid-seq-json/steps-and-requests.seq.json
+++ b/test/valid-seq-json/steps-and-requests.seq.json
@@ -48,7 +48,7 @@
   ],
   "steps": [
     {
-      "args": [30, 4.3, true, "test_string"],
+      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",
@@ -68,10 +68,10 @@
     },
     {
       "args": [
-        30,
-        4.3,
-        false,
-        "test_string",
+        { "number": 30 },
+        { "number": 4.3 },
+        { "boolean": false },
+        { "string": "test_string" },
         {
           "symbol": "Global_Var_A"
         }

--- a/types.ts
+++ b/types.ts
@@ -63,7 +63,7 @@ export type Step = Activate | Command | GroundBlock | GroundEvent | Load;
 /**
  * Array of command arguments
  */
-export type Args = (string | number | boolean | SymbolArgument | HexArgument)[];
+export type Args = (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[];
 export type Request1 =
   | {
       [k: string]: unknown;
@@ -163,6 +163,33 @@ export interface Activate {
   sequence: string;
   time: Time;
   type: 'activate';
+}
+/**
+ * A step argument containing a string.
+ */
+export interface StringArgument {
+  /**
+   * The value. The string must be valid.
+   */
+  string: string;
+}
+/**
+ * A step argument containing a number.
+ */
+export interface NumberArgument {
+  /**
+   * The value. The number must be valid.
+   */
+  number: number;
+}
+/**
+ * A step argument containing a boolean.
+ */
+export interface BooleanArgument {
+  /**
+   * The boolean value. The value must be all lowercase.
+   */
+  boolean: boolean;
 }
 /**
  * A step argument referencing a local or global variable, or some other symbolic name known to downstream modeling software (such as CONDITION in SEQGEN)


### PR DESCRIPTION
Closes #2.

This PR updates the 3 primitive types (`string`, `number`, and `boolean`) for `args` to objects.

Hopefully I caught all the tests, there were quite a few that included the primitive types...