### PR TITLE
Added repeat args, included them in the all-possible-fields test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,9 @@
           },
           {
             "$ref": "#/$defs/hex_argument"
+          },
+          {
+            "$ref": "#/$defs/repeat_argument"
           }
         ]
       }
@@ -397,6 +400,39 @@
       },
       "required": ["symbol"],
       "type": "object"
+    },
+    "repeat_argument": {
+      "additionalProperties": false,
+      "description": "",
+      "properties": {
+        "repeat": {
+          "description": "A repeat argument, there can be a nested repeat argument inside.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/string_argument"
+              },
+              {
+                "$ref": "#/$defs/number_argument"
+              },
+              {
+                "$ref": "#/$defs/boolean_argument"
+              },
+              {
+                "$ref": "#/$defs/symbol_argument"
+              },
+              {
+                "$ref": "#/$defs/hex_argument"
+              },
+              {
+                "$ref": "#/$defs/repeat_argument"
+              }
+            ]
+          }
+        }
+      },
+      "required": ["repeat"]
     },
     "string_argument": {
       "additionalProperties": false,

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
   name='seq-json-schema',
   packages=['seq-json-schema'],
   url='https://github.com/NASA-AMMOS/seq-json-schema',
-  version='1.0.11'
+  version='1.0.12'
 )

--- a/test/invalid-seq-json/variable-argument-repeat-missing-tag.json
+++ b/test/invalid-seq-json/variable-argument-repeat-missing-tag.json
@@ -1,0 +1,13 @@
+{
+  "id": "variable_argument_repeat_missing_tag",
+  "metadata": {},
+  "steps": [
+    {
+      "args": [
+        {
+          "repeat": [[{ "number": 1 }]]
+        }
+      ]
+    }
+  ]
+}

--- a/test/valid-seq-json/all-possible-fields.seq.json
+++ b/test/valid-seq-json/all-possible-fields.seq.json
@@ -44,7 +44,20 @@
   ],
   "steps": [
     {
-      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
+      "args": [
+        { "number": 30 },
+        { "number": 4.3 },
+        { "boolean": true },
+        { "string": "test_string" },
+        {
+          "repeat": [
+            { "number": 10 },
+            { "string": "another_test" },
+            { "boolean": false },
+            { "repeat": [{ "number": 1 }] }
+          ]
+        }
+      ],
       "description": "Epoch-relative activate step for test.mod into engine 2 with all possible fields.",
       "engine": 2,
       "epoch": "TEST_EPOCH",
@@ -75,7 +88,13 @@
       "type": "activate"
     },
     {
-      "args": [{ "number": 30 }, { "number": 4.3 }, { "boolean": true }, { "string": "test_string" }],
+      "args": [
+        { "number": 30 },
+        { "number": 4.3 },
+        { "boolean": true },
+        { "string": "test_string" },
+        { "repeat": [{ "number": 10 }, { "string": "another_test" }] }
+      ],
       "description": "Absolute-timed standard command step with all possible fields.",
       "models": [
         {

--- a/types.ts
+++ b/types.ts
@@ -63,7 +63,14 @@ export type Step = Activate | Command | GroundBlock | GroundEvent | Load;
 /**
  * Array of command arguments
  */
-export type Args = (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument)[];
+export type Args = (
+  | StringArgument
+  | NumberArgument
+  | BooleanArgument
+  | SymbolArgument
+  | HexArgument
+  | RepeatArgument
+)[];
 export type Request1 =
   | {
       [k: string]: unknown;
@@ -208,6 +215,12 @@ export interface HexArgument {
    * The hexadecimal integer, as a string prefixed with 0x. Digits A-F must be uppercase.
    */
   hex: string;
+}
+export interface RepeatArgument {
+  /**
+   * A repeat argument, there can be a nested repeat argument inside.
+   */
+  repeat: (StringArgument | NumberArgument | BooleanArgument | SymbolArgument | HexArgument | RepeatArgument)[];
 }
 /**
  * Model object that be included with commands to set variables for modeling purposes only, usually to direct sequence execution down a particular branch during modeling.


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/seq-json-schema/issues/1

* Added a nested repeat to our test
* Added an invalid test for repeat args, updated package-json lock
* Added a repeat arg type to command arguments that is represented as a list of objects