### PR TITLE
Bugfix: package json missing in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include seq-json-schema/schema.json
+include seq-json-schema/schema.json package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.0.20",
+  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.0.21",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
     "activate": {


### PR DESCRIPTION
Version 1.0.20 is uninstallable with Python because the package.json is missing from the sdist.

This PR ensures the version can be read from the package.json.