### PR TITLE
Immediate versions of `load` and `activate`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.0.21",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -2,6 +2,44 @@
   "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.0.21",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
+    "immediate_activate": {
+      "additionalProperties": false,
+      "description": "Untimed activate object",
+      "properties": {
+        "args": {
+          "$ref": "#/$defs/args"
+        },
+        "description": {
+          "$ref": "#/$defs/description"
+        },
+        "engine": {
+          "type": "integer",
+          "description": "Sequence target engine."
+        },
+        "epoch": {
+          "type": "string",
+          "description": "Onboard epoch to pass to the sequence for derivation of epoch-relative timetags"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "models": {
+          "items": {
+            "$ref": "#/$defs/model"
+          },
+          "type": "array"
+        },
+        "sequence": {
+          "type": "string",
+          "description": "Onboard path and filename of sequence to be loaded."
+        },
+        "type": {
+          "const": "activate"
+        }
+      },
+      "required": ["sequence", "type"],
+      "type": "object"
+    },
     "activate": {
       "additionalProperties": false,
       "description": "Activate object",
@@ -69,6 +107,30 @@
         ]
       }
     },
+    "immediate_fsw_command": {
+      "additionalProperties": false,
+      "description": "Object representing a single Immediate Command",
+      "properties": {
+        "args": {
+          "$ref": "#/$defs/args"
+        },
+        "description": {
+          "$ref": "#/$defs/description"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "stem": {
+          "type": "string",
+          "description": "Command stem"
+        },
+        "type": {
+          "const": "command"
+        }
+      },
+      "required": ["stem", "args"],
+      "type": "object"
+    },
     "command": {
       "additionalProperties": false,
       "description": "Command object",
@@ -82,25 +144,25 @@
         "metadata": {
           "$ref": "#/$defs/metadata"
         },
+        "stem": {
+          "type": "string",
+          "description": "Command stem"
+        },
         "models": {
           "items": {
             "$ref": "#/$defs/model"
           },
           "type": "array"
         },
-        "stem": {
-          "type": "string",
-          "description": "Command stem"
-        },
         "time": {
           "$ref": "#/$defs/time"
-        },
-        "type": {
-          "const": "command"
         },
         "return_assign_to": {
           "description": "Name of a defined local variable to which the exit status of this command should be written to. For this to work, that local variable must have been defined with the 'SC_Name' property set to LCS",
           "type": "string"
+        },
+        "type": {
+          "const": "command"
         }
       },
       "required": ["stem", "args", "time", "type"],
@@ -188,6 +250,44 @@
         }
       },
       "required": ["name", "time", "type"],
+      "type": "object"
+    },
+    "immediate_load": {
+      "additionalProperties": false,
+      "description": "Untimed load object",
+      "properties": {
+        "args": {
+          "$ref": "#/$defs/args"
+        },
+        "description": {
+          "$ref": "#/$defs/description"
+        },
+        "engine": {
+          "type": "integer",
+          "description": "Sequence target engine."
+        },
+        "epoch": {
+          "type": "string",
+          "description": "Onboard epoch to pass to the sequence for derivation of epoch-relative timetags"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "models": {
+          "items": {
+            "$ref": "#/$defs/model"
+          },
+          "type": "array"
+        },
+        "sequence": {
+          "type": "string",
+          "description": "Onboard path and filename of sequence to be loaded."
+        },
+        "type": {
+          "const": "load"
+        }
+      },
+      "required": ["sequence", "type"],
       "type": "object"
     },
     "load": {
@@ -316,27 +416,6 @@
           "$ref": "#/$defs/load"
         }
       ]
-    },
-    "immediate_command": {
-      "additionalProperties": false,
-      "description": "Object representing a single Immediate Command",
-      "properties": {
-        "args": {
-          "$ref": "#/$defs/args"
-        },
-        "description": {
-          "$ref": "#/$defs/description"
-        },
-        "metadata": {
-          "$ref": "#/$defs/metadata"
-        },
-        "stem": {
-          "type": "string",
-          "description": "Command stem"
-        }
-      },
-      "required": ["stem", "args"],
-      "type": "object"
     },
     "hardware_command": {
       "additionalProperties": false,
@@ -674,7 +753,17 @@
     "immediate_commands": {
       "description": "Immediate commands which are interpreted by FSW and not part of any sequence.",
       "items": {
-        "$ref": "#/$defs/immediate_command"
+        "oneOf": [
+          {
+            "$ref": "#/$defs/immediate_fsw_command"
+          },
+          {
+            "$ref": "#/$defs/immediate_load"
+          },
+          {
+            "$ref": "#/$defs/immediate_activate"
+          }
+        ]
       },
       "type": "array"
     },

--- a/schema.json
+++ b/schema.json
@@ -144,25 +144,25 @@
         "metadata": {
           "$ref": "#/$defs/metadata"
         },
-        "stem": {
-          "type": "string",
-          "description": "Command stem"
-        },
         "models": {
           "items": {
             "$ref": "#/$defs/model"
           },
           "type": "array"
         },
+        "stem": {
+          "type": "string",
+          "description": "Command stem"
+        },
         "time": {
           "$ref": "#/$defs/time"
+        },
+        "type": {
+          "const": "command"
         },
         "return_assign_to": {
           "description": "Name of a defined local variable to which the exit status of this command should be written to. For this to work, that local variable must have been defined with the 'SC_Name' property set to LCS",
           "type": "string"
-        },
-        "type": {
-          "const": "command"
         }
       },
       "required": ["stem", "args", "time", "type"],

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.0.21",
+  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.1.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
     "immediate_activate": {

--- a/test/invalid-seq-json/immediate-activate-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-activate-with-time.seq.json
@@ -1,0 +1,15 @@
+{
+  "id": "immediate-activate-with-time",
+  "metadata": {},
+  "immediate_commands": [
+    {
+      "args": [],
+      "sequence": "d:/eng/test.mod",
+      "description": "immediate activate with time field",
+      "type": "activate",
+      "time": {
+        "type": "COMMAND_RELATIVE"
+      }
+    }
+  ]
+}

--- a/test/invalid-seq-json/immediate-command-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-command-with-time.seq.json
@@ -1,0 +1,17 @@
+{
+  "id": "immediate-command-with-time",
+  "metadata": {},
+  "immediate_commands": [
+    {
+      "stem": "NOOP",
+      "description": "immediate command with time field",
+      "metadata": {
+        "processor": "VC1A"
+      },
+      "args": [],
+      "time": {
+        "type": "COMMAND_COMPLETE"
+      }
+    }
+  ]
+}

--- a/test/invalid-seq-json/immediate-load-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-load-with-time.seq.json
@@ -1,0 +1,15 @@
+{
+  "id": "immediate-load-with-time",
+  "metadata": {},
+  "immediate_commands": [
+    {
+      "args": [],
+      "sequence": "d:/eng/test.mod",
+      "description": "immediate load with time field",
+      "type": "load",
+      "time": {
+        "type": "COMMAND_RELATIVE"
+      }
+    }
+  ]
+}

--- a/test/valid-seq-json/rtc.seq.json
+++ b/test/valid-seq-json/rtc.seq.json
@@ -12,9 +12,18 @@
     {
       "stem": "IC",
       "args": [
-        { "type": "string", "value": "1" },
-        { "type": "number", "value": 2 },
-        { "type": "number", "value": 3.0 }
+        {
+          "type": "string",
+          "value": "1"
+        },
+        {
+          "type": "number",
+          "value": 2
+        },
+        {
+          "type": "number",
+          "value": 3.0
+        }
       ],
       "description": "immediate command",
       "metadata": {}
@@ -22,8 +31,65 @@
     {
       "stem": "NOOP",
       "description": "noop command, no arguments",
-      "metadata": { "processor": "VC1A" },
+      "metadata": {
+        "processor": "VC1A"
+      },
       "args": []
+    },
+    {
+      "stem": "NOOP",
+      "description": "noop command, no arguments, with optional type",
+      "metadata": {
+        "processor": "VC1A"
+      },
+      "args": [],
+      "type": "command"
+    },
+    {
+      "args": [
+        {
+          "type": "number",
+          "value": 30
+        }
+      ],
+      "description": "Immediate activate step.",
+      "engine": 2,
+      "epoch": "TEST_EPOCH",
+      "models": [
+        {
+          "offset": "00:00:00.000",
+          "variable": "model_var_float",
+          "value": "1.234"
+        }
+      ],
+      "sequence": "d:/eng/test.mod",
+      "type": "activate",
+      "metadata": {
+        "metadata_arg": "metadata_value"
+      }
+    },
+    {
+      "args": [
+        {
+          "type": "number",
+          "value": 30
+        }
+      ],
+      "description": "Immediate load step.",
+      "engine": 2,
+      "epoch": "TEST_EPOCH",
+      "models": [
+        {
+          "offset": "00:00:00.000",
+          "variable": "model_var_float",
+          "value": "1.234"
+        }
+      ],
+      "sequence": "d:/eng/test.mod",
+      "type": "load",
+      "metadata": {
+        "metadata_arg": "metadata_value"
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for your Pull Request! -->
<!-- Please make sure your commit increments the package version in package.json, package-lock.json, and schema.json. -->

Updates the schema to create versions of `load` and `activate` without `time` properties, renames `immediate_command` to `immediate_fsw_command`, and makes these types valid for `immediate_commands`.