### PR TITLE
small improvements to GH workflows + gitignore

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -10,8 +10,8 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: 'lts/*'
@@ -20,6 +20,5 @@ jobs:
         run: npm ci
       - name: Publish
         run: npm publish
-        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,19 +10,19 @@ jobs:
   publish-to-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           cp schema.json seq-json-schema/
           python3 setup.py sdist
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           print_hash: true
           verbose: true
       - name: Cleanup
+        if: always()
         run: |
           rm -rf *.egg-info dist
           rm seq-json-schema/schema.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - uses: actions/setup-python@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.egg-info
+.idea/
 seq-json-schema/*.json
 build
 dist


### PR DESCRIPTION
* Remove `continue-on-error: true` to prevent silent failures when publishing packages
* Update versions of deprecated GH actions
* add `.idea` to gitignore (webstorm internal folder)
* Run tests on node 20 (it's doing this anyway bc node 18 is deprecated in actions)