### PR TITLE
Update RTC's Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",
@@ -161,14 +161,15 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -207,6 +208,27 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
@@ -714,13 +736,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       }
     },
@@ -755,6 +778,26 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+          "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+          "dev": true
+        }
       }
     },
     "event-emitter": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.1.0",
+  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.2.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
     "immediate_activate": {
@@ -34,7 +34,7 @@
           "description": "Onboard path and filename of sequence to be loaded."
         },
         "type": {
-          "const": "activate"
+          "const": "immediate_activate"
         }
       },
       "required": ["sequence", "type"],
@@ -120,12 +120,18 @@
         "metadata": {
           "$ref": "#/$defs/metadata"
         },
+        "models": {
+          "items": {
+            "$ref": "#/$defs/model"
+          },
+          "type": "array"
+        },
         "stem": {
           "type": "string",
           "description": "Command stem"
         },
         "type": {
-          "const": "command"
+          "const": "immediate_command"
         }
       },
       "required": ["stem", "args"],
@@ -284,7 +290,7 @@
           "description": "Onboard path and filename of sequence to be loaded."
         },
         "type": {
-          "const": "load"
+          "const": "immediate_load"
         }
       },
       "required": ["sequence", "type"],

--- a/test/invalid-seq-json/immediate-activate-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-activate-with-time.seq.json
@@ -6,7 +6,7 @@
       "args": [],
       "sequence": "d:/eng/test.mod",
       "description": "immediate activate with time field",
-      "type": "activate",
+      "type": "immediate_activate",
       "time": {
         "type": "COMMAND_RELATIVE"
       }

--- a/test/invalid-seq-json/immediate-command-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-command-with-time.seq.json
@@ -11,7 +11,8 @@
       "args": [],
       "time": {
         "type": "COMMAND_COMPLETE"
-      }
+      },
+      "type": "immediate_command"
     }
   ]
 }

--- a/test/invalid-seq-json/immediate-load-with-time.seq.json
+++ b/test/invalid-seq-json/immediate-load-with-time.seq.json
@@ -6,7 +6,7 @@
       "args": [],
       "sequence": "d:/eng/test.mod",
       "description": "immediate load with time field",
-      "type": "load",
+      "type": "immediate_load",
       "time": {
         "type": "COMMAND_RELATIVE"
       }

--- a/test/valid-seq-json/rtc.seq.json
+++ b/test/valid-seq-json/rtc.seq.json
@@ -34,6 +34,13 @@
       "metadata": {
         "processor": "VC1A"
       },
+      "models": [
+        {
+          "offset": "00:10:00.000",
+          "variable": "model_var_float",
+          "value": "1.62"
+        }
+      ],
       "args": []
     },
     {
@@ -42,8 +49,9 @@
       "metadata": {
         "processor": "VC1A"
       },
+      
       "args": [],
-      "type": "command"
+      "type": "immediate_command"
     },
     {
       "args": [
@@ -63,7 +71,7 @@
         }
       ],
       "sequence": "d:/eng/test.mod",
-      "type": "activate",
+      "type": "immediate_activate",
       "metadata": {
         "metadata_arg": "metadata_value"
       }
@@ -86,7 +94,7 @@
         }
       ],
       "sequence": "d:/eng/test.mod",
-      "type": "load",
+      "type": "immediate_load",
       "metadata": {
         "metadata_arg": "metadata_value"
       }


### PR DESCRIPTION
I updated the `immediate_load` and `immediate_activate` types to be specific

ex.
```json
immediate_load{
        "args": {
          "$ref": "#/$defs/args"
        },
        "description": {
          "$ref": "#/$defs/description"
        },
        "engine": {
          "type": "integer",
          "description": "Sequence target engine."
        },
        "type": {
          "const": "load" <------------------------ making this 'immediate_load'
        }
}
```

Also for consistency I added `model` attribute from `immediateFSWCommands`. I verified with Taifun, Carter, and Mike Schaffer of these changes and they were onboard with it. 