### PR TITLE
Improve schema for Time object to generate better TS types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/seq-json-schema",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/seq-json-schema",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -477,30 +477,32 @@
     "time": {
       "additionalProperties": false,
       "description": "Time object",
-      "properties": {
-        "tag": {
-          "description": "Relative or absolute time. Required for ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, and EPOCH_RELATIVE time types but not COMMAND_COMPLETE.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Allowed time types: ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, EPOCH_RELATIVE, or COMMAND_COMPLETE.",
-          "enum": ["ABSOLUTE", "BLOCK_RELATIVE", "COMMAND_RELATIVE", "EPOCH_RELATIVE", "COMMAND_COMPLETE"],
-          "type": "string"
-        }
-      },
-      "required": ["type"],
-      "allOf": [
+      "oneOf": [
         {
-          "if": {
-            "properties": {
-              "type": {
-                "enum": ["ABSOLUTE", "BLOCK_RELATIVE", "COMMAND_RELATIVE", "EPOCH_RELATIVE"]
-              }
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "Allowed time types without a tag: COMMAND_COMPLETE",
+              "enum": ["COMMAND_COMPLETE"],
+              "type": "string"
             }
           },
-          "then": {
-            "required": ["tag"]
-          }
+          "required": ["type"]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "Allowed time types with a tag: ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, EPOCH_RELATIVE.",
+              "enum": ["ABSOLUTE", "BLOCK_RELATIVE", "COMMAND_RELATIVE", "EPOCH_RELATIVE"],
+              "type": "string"
+            },
+            "tag": {
+              "description": "Relative or absolute time. Required for ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, and EPOCH_RELATIVE time types but not COMMAND_COMPLETE.",
+              "type": "string"
+            }
+          },
+          "required": ["type", "tag"]
         }
       ],
       "type": "object"

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.3.0",
+  "$id": "https://github.com/NASA-AMMOS/seq-json-schema/tree/v1.3.1",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
     "immediate_activate": {

--- a/schema.json
+++ b/schema.json
@@ -475,7 +475,6 @@
       "type": "object"
     },
     "time": {
-      "additionalProperties": false,
       "description": "Time object",
       "oneOf": [
         {

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,28 @@ import Ajv from 'ajv/dist/2020.js';
 import schema from '../schema.json' assert { type: 'json' };
 import { readdirSync, readFileSync } from 'fs';
 import { exit } from 'process';
+import packageJson from '../package.json' assert { type: 'json' };
+import lockfileJson from '../package-lock.json' assert { type: 'json' };
+
+function testVersions(failures) {
+  // Make sure version strings match
+  const schemaId = schema.$id;
+  const versionMatch = schemaId.match(/\/v(\d+\.\d+\.\d+)$/);
+  if(!versionMatch) throw "Cannot find version in schema.json $id field";
+  const schemaVersion = versionMatch ? versionMatch[1] : null;
+
+  const packageVersion = packageJson.version;
+  const lockfileVersion = lockfileJson.version;
+
+  if(schemaVersion !== packageVersion || schemaVersion !== lockfileVersion) {
+    const msg = "Versions in schema.json, package.json and package-lock.json must match";
+    failures.push(msg);
+    console.error(`❌ ${msg}`);
+    console.log(`schema version in schema.$id: ${schemaVersion}`);
+    console.log(`package.json version: ${packageVersion}`);
+    console.log(`package-lock.json version: ${lockfileVersion}`);
+  }
+}
 
 function test() {
   const ajv = new Ajv({
@@ -14,6 +36,8 @@ function test() {
   const invalidSeqJsonPath = './test/invalid-seq-json';
   const invalidSeqJsonFiles = readdirSync(invalidSeqJsonPath);
   const failures = [];
+
+  testVersions(failures);
 
   // Valid Seq JSON.
   for (const validSeqJsonFile of validSeqJsonFiles) {

--- a/test/test.js
+++ b/test/test.js
@@ -4,30 +4,43 @@ import { readdirSync, readFileSync } from 'fs';
 import { exit } from 'process';
 
 function test() {
-  const validate = new Ajv({ strict: false }).compile(schema);
+  const ajv = new Ajv({
+    strict: false,
+    verbose: true,
+  });
+  const validate = ajv.compile(schema);
   const validSeqJsonPath = './test/valid-seq-json';
   const validSeqJsonFiles = readdirSync(validSeqJsonPath);
   const invalidSeqJsonPath = './test/invalid-seq-json';
   const invalidSeqJsonFiles = readdirSync(invalidSeqJsonPath);
-  const errors = [];
+  const failures = [];
 
   // Valid Seq JSON.
   for (const validSeqJsonFile of validSeqJsonFiles) {
     const validSeqJson = readFileSync(`${validSeqJsonPath}/${validSeqJsonFile}`).toString();
     const valid = validate(JSON.parse(validSeqJson));
-    if (!valid) errors.push(`${validSeqJsonFile} should be valid`);
+    if (!valid) {
+      // most relevant errors tend to be at the bottom - reverse list
+      const errors = validate.errors.reverse();
+      console.error(`❌ Failed to validate ${validSeqJsonFile} - ${errors.length} errors:`);
+      console.log(errors);
+      failures.push(`${validSeqJsonFile} should be valid`);
+    }
   }
 
   // Invalid Seq JSON.
   for (const invalidSeqJsonFile of invalidSeqJsonFiles) {
     const invalidSeqJson = readFileSync(`${invalidSeqJsonPath}/${invalidSeqJsonFile}`).toString();
     const valid = validate(JSON.parse(invalidSeqJson));
-    if (valid) errors.push(`${invalidSeqJsonFile} should be invalid`);
+    if (valid) {
+      console.error(`❌ Failed to invalidate ${invalidSeqJsonFile} - expected errors`);
+      failures.push(`${invalidSeqJsonFile} should be invalid`);
+    }
   }
 
-  if (errors.length) {
-    console.log('❌ Some tests failed...');
-    console.error(errors);
+  if (failures.length) {
+    console.log(`❌ ${failures.length} tests failed...`);
+    console.error(failures);
     exit(1);
   } else {
     console.log('✅ All tests passed!');

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,7 @@ function test() {
     const valid = validate(JSON.parse(validSeqJson));
     if (!valid) {
       // most relevant errors tend to be at the bottom - reverse list
-      const errors = validate.errors.reverse();
+      const errors = validate.errors.slice().reverse();
       console.error(`❌ Failed to validate ${validSeqJsonFile} - ${errors.length} errors:`);
       console.log(errors);
       failures.push(`${validSeqJsonFile} should be valid`);


### PR DESCRIPTION
For context see [this PR discussion](https://github.com/NASA-AMMOS/aerie-ui/pull/1600#discussion_r1934397867). This is a bugfix to an existing schema rule, not a proposed change to functionality.

PR #32 made some updates to the `time` type/sub-schema to make the requirement of the `"tag"` field *conditional* on the command's type. This was implemented with a JSON schema `if`/`then` block, which is legal in JSON schema. However it turns out that our [typescript types generator](https://github.com/NASA-AMMOS/seq-json-schema/blob/develop/scripts/generate-types.js) does not handle `if`/`then` blocks gracefully, and [generated some types](https://github.com/NASA-AMMOS/aerie-ui/pull/1600#discussion_r1934397867) that did not correctly enforce the rules from the schema.

This PR reimplements the same schema rules using only `oneOf` blocks instead of `if`/`then`, which do generate TS types that enforce the rules. Whenever possible we should try to avoid `if`/`then` blocks in the schema - generally they do not *break* things, but they can result in TS types which have looser rules than the underlying schema & do not throw errors when they should.

New TS types generated by this (`npm run types`):
```ts
/**
 * Time object
 */
export type Time =
  | {
      /**
       * Allowed time types without a tag: COMMAND_COMPLETE
       */
      type: 'COMMAND_COMPLETE';
    }
  | {
      /**
       * Allowed time types with a tag: ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, EPOCH_RELATIVE.
       */
      type: 'ABSOLUTE' | 'BLOCK_RELATIVE' | 'COMMAND_RELATIVE' | 'EPOCH_RELATIVE';
      /**
       * Relative or absolute time. Required for ABSOLUTE, BLOCK_RELATIVE, COMMAND_RELATIVE, and EPOCH_RELATIVE time types but not COMMAND_COMPLETE.
       */
      tag: string;
    };
```